### PR TITLE
Allow regular expression validity to be tested

### DIFF
--- a/src/OpenConext/Value/RegularExpression.php
+++ b/src/OpenConext/Value/RegularExpression.php
@@ -11,6 +11,22 @@ final class RegularExpression
      */
     private $pattern;
 
+    public static function isValidRegularExpression($regularExpression)
+    {
+        $pregMatchErrored = false;
+        set_error_handler(
+            function () use (&$pregMatchErrored) {
+                $pregMatchErrored = true;
+            }
+        );
+
+        preg_match($regularExpression, 'some test string');
+
+        restore_error_handler();
+
+        return !$pregMatchErrored && !preg_last_error();
+    }
+
     /**
      * @param string $pattern
      */
@@ -20,7 +36,7 @@ final class RegularExpression
             throw InvalidArgumentException::invalidType('non-blank string', 'pattern', $pattern);
         }
 
-        if (!$this->isValidRegularExpression($pattern)) {
+        if (!self::isValidRegularExpression($pattern)) {
             throw new InvalidArgumentException(sprintf(
                 'The pattern "%s" is not a valid regular expression',
                 $pattern
@@ -55,19 +71,5 @@ final class RegularExpression
     public function __toString()
     {
         return $this->pattern;
-    }
-
-    private function isValidRegularExpression($regularExpression)
-    {
-        $pregMatchErrored = false;
-        set_error_handler(function () use (&$pregMatchErrored) {
-            $pregMatchErrored = true;
-        });
-
-        preg_match($regularExpression, 'some test string');
-
-        restore_error_handler();
-
-        return !$pregMatchErrored && !preg_last_error();
     }
 }

--- a/src/OpenConext/Value/RegularExpression.php
+++ b/src/OpenConext/Value/RegularExpression.php
@@ -14,11 +14,9 @@ final class RegularExpression
     public static function isValidRegularExpression($regularExpression)
     {
         $pregMatchErrored = false;
-        set_error_handler(
-            function () use (&$pregMatchErrored) {
-                $pregMatchErrored = true;
-            }
-        );
+        set_error_handler(function () use (&$pregMatchErrored) {
+            $pregMatchErrored = true;
+        });
 
         preg_match($regularExpression, 'some test string');
 

--- a/src/OpenConext/Value/Saml/Metadata/ShibbolethMetadataScope.php
+++ b/src/OpenConext/Value/Saml/Metadata/ShibbolethMetadataScope.php
@@ -63,7 +63,7 @@ final class ShibbolethMetadataScope
             throw InvalidArgumentException::invalidType('string', 'string', $string);
         }
 
-        if ($this->literal) {
+        if ($this->literal !== null) {
             return $this->literal === $string;
         }
 
@@ -76,7 +76,7 @@ final class ShibbolethMetadataScope
      */
     public function equals(ShibbolethMetadataScope $other)
     {
-        return ($this->literal && $this->literal === $other->literal)
+        return ($this->literal !== null && $this->literal === $other->literal)
                 || ($this->regexp && $other->regexp && $this->regexp->equals($other->regexp));
     }
 

--- a/tests/OpenConext/Value/RegularExpressionTest.php
+++ b/tests/OpenConext/Value/RegularExpressionTest.php
@@ -23,6 +23,16 @@ class RegularExpressionTest extends UnitTest
      * @test
      * @group        value
      * @dataProvider \OpenConext\Value\TestDataProvider::invalidRegularExpressionProvider
+     */
+    public function a_regex_can_be_tested_for_being_valid($invalidExpression)
+    {
+       $this->assertFalse(RegularExpression::isValidRegularExpression($invalidExpression));
+    }
+
+    /**
+     * @test
+     * @group        value
+     * @dataProvider \OpenConext\Value\TestDataProvider::invalidRegularExpressionProvider
      *
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
This opens the door to validating regular expressions
before creating a RegularExpression object. This means
you do not have to catch an Exception if the pattern
is invalid, but rather can test for it.
