### PR TITLE
Wrong (re)declaration of isCallable

### DIFF
--- a/src/OpenConext/Value/Assert/Assertion.php
+++ b/src/OpenConext/Value/Assert/Assertion.php
@@ -84,7 +84,7 @@ class Assertion extends BaseAssertion
      * @param null|string $message
      * @param string      $propertyPath
      */
-    public static function isCallable($value, $propertyPath, $message = null)
+    public static function isCallable($value, $message = null, $propertyPath = null)
     {
         $message = $message ?: 'Expected a callable for "%s", got a "%s"';
         if (!is_callable($value)) {


### PR DESCRIPTION
I know there is a pull request to remove isCallable declaration in Assert by upgrading Beberlei/assert, but as long as that is not accepted, this declaration of isCallable breaks EB:

Declaration of OpenConext\Value\Assert\Assertion::isCallable($value, $message, $propertyPath) should be compatible with Assert\Assertion::isCallable($value, $message = NULL, $propertyPath = NULL) [/opt/OpenConext/OpenConext-engineblock-5.0.0/vendor/openconext/saml-value-object/src/OpenConext/Value/Assert/Assertion.php:0]
