### PR TITLE
Restore error messages on callable assertions

### DIFF
--- a/src/OpenConext/Value/Saml/Metadata/ContactPerson/EmailAddressList.php
+++ b/src/OpenConext/Value/Saml/Metadata/ContactPerson/EmailAddressList.php
@@ -90,7 +90,7 @@ final class EmailAddressList implements Countable, IteratorAggregate, Serializab
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->emailAddresses as $emailAddress) {
             if (call_user_func($predicate, $emailAddress) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/ContactPerson/TelephoneNumberList.php
+++ b/src/OpenConext/Value/Saml/Metadata/ContactPerson/TelephoneNumberList.php
@@ -90,7 +90,7 @@ final class TelephoneNumberList implements Countable, IteratorAggregate, Seriali
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->telephoneNumbers as $telephoneNumber) {
             if (call_user_func($predicate, $telephoneNumber) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/ContactPersonList.php
+++ b/src/OpenConext/Value/Saml/Metadata/ContactPersonList.php
@@ -90,7 +90,7 @@ final class ContactPersonList implements Countable, IteratorAggregate, Serializa
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->contactPersons as $contactPerson) {
             if (call_user_func($predicate, $contactPerson) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationDisplayNameList.php
+++ b/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationDisplayNameList.php
@@ -112,7 +112,7 @@ final class OrganizationDisplayNameList implements Countable, IteratorAggregate,
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->organizationDisplayNames as $organizationDisplayName) {
             if (call_user_func($predicate, $organizationDisplayName) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationNameList.php
+++ b/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationNameList.php
@@ -90,7 +90,7 @@ final class OrganizationNameList implements Countable, IteratorAggregate, Serial
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->organizationNames as $organizationName) {
             if (call_user_func($predicate, $organizationName) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationUrlList.php
+++ b/src/OpenConext/Value/Saml/Metadata/Organization/OrganizationUrlList.php
@@ -90,7 +90,7 @@ final class OrganizationUrlList implements Countable, IteratorAggregate, Seriali
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->organizationUrls as $organizationUrl) {
             if (call_user_func($predicate, $organizationUrl) === true) {

--- a/src/OpenConext/Value/Saml/Metadata/ShibbolethMetadataScopeList.php
+++ b/src/OpenConext/Value/Saml/Metadata/ShibbolethMetadataScopeList.php
@@ -110,7 +110,7 @@ final class ShibbolethMetadataScopeList implements Countable, IteratorAggregate,
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->scopes as $shibbolethMetadataScope) {
             if (call_user_func($predicate, $shibbolethMetadataScope) === true) {

--- a/src/OpenConext/Value/Saml/NameIdFormatList.php
+++ b/src/OpenConext/Value/Saml/NameIdFormatList.php
@@ -90,7 +90,7 @@ final class NameIdFormatList implements Countable, IteratorAggregate, Serializab
      */
     public function find($predicate)
     {
-        Assertion::isCallable($predicate, 'predicate');
+        Assertion::isCallable($predicate, null, 'predicate');
 
         foreach ($this->nameIdFormats as $nameIdFormat) {
             if (call_user_func($predicate, $nameIdFormat) === true) {


### PR DESCRIPTION
Commit 21b789b switched the isCallable assertions from a custom
implementation to the one from the beberlei assert library. It did not
take into account the signature change of the method.

The signature was: callable value, property path, error message
The signature changed to: callable value, error message, property path

This commit updates all uses of isCallable to the new
signature. Without this fix, all error messages are 'predicate'
instead of the default error message.